### PR TITLE
Enhance master data forms and validation focus

### DIFF
--- a/src/routes/InstructionListPage.tsx
+++ b/src/routes/InstructionListPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from 'react';
+import { FormEvent, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { useInstructions, useInstructionMutations } from '../features/instructions/hooks/useInstructions';
@@ -18,6 +18,8 @@ const InstructionListPage = () => {
   const [isCreating, setIsCreating] = useState(false);
   const [showValidation, setShowValidation] = useState(false);
   const [isCreateSectionOpen, setIsCreateSectionOpen] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
   const [filters, setFilters] = useState({
     title: '',
     goal: '',
@@ -55,6 +57,11 @@ const InstructionListPage = () => {
     if (hasMissingRequired) {
       setShowValidation(true);
       showToast({ message: 'Vui lòng điền đầy đủ tiêu đề và nội dung chính.', type: 'error' });
+      if (!newInstruction.title.trim()) {
+        titleRef.current?.focus();
+      } else if (!newInstruction.body.trim()) {
+        bodyRef.current?.focus();
+      }
       return;
     }
     setIsCreating(true);
@@ -153,6 +160,7 @@ const InstructionListPage = () => {
                   onChange={(event) => setNewInstruction((prev) => ({ ...prev, title: event.target.value }))}
                   onBlur={() => setShowValidation(true)}
                   className={requiredInputClasses(showValidation && !newInstruction.title.trim())}
+                  ref={titleRef}
                 />
               </div>
               <div>
@@ -186,6 +194,7 @@ const InstructionListPage = () => {
                   onChange={(event) => setNewInstruction((prev) => ({ ...prev, body: event.target.value }))}
                   onBlur={() => setShowValidation(true)}
                   className={requiredInputClasses(showValidation && !newInstruction.body.trim())}
+                  ref={bodyRef}
                 />
               </div>
               <div>


### PR DESCRIPTION
## Summary
- add focus handling to master data and instruction creation forms so the first missing required field is highlighted for quick correction
- populate master data select fields from reference datasets and render them as dropdowns for provinces and cost types
- wire reference data lookups and field refs to keep validation and closing/reset flows consistent

## Testing
- npm run lint
- npm run typecheck *(fails: Referenced project '/workspace/CursorTourCost/tsconfig.node.json' may not disable emit.)*
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d4b2986fb08323b684f1011cf664f6