### PR TITLE
Fix API base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ npm install
 npm run dev
 ```
 
+Tạo file `.env.local` (hoặc cập nhật biến môi trường tương ứng) với cấu hình API:
+
+```
+VITE_API_BASE=https://asia-southeast1-quantum-ratio-468010-d4.cloudfunctions.net/api
+```
+
+Khi triển khai production, thay giá trị trên bằng domain thực tế của Cloud Functions. Nếu cần gọi emulator
+local, đặt `VITE_API_BASE=http://127.0.0.1:5001/<project>/<region>/api`.
+
 Ứng dụng đọc cấu hình Firebase trực tiếp từ `src/lib/firebase.ts`. Có thể bật emulator bằng cách set `VITE_USE_FIREBASE_EMULATORS=true` trong `.env.local`.
 
 ## Chức năng chính

--- a/src/features/ai/api.ts
+++ b/src/features/ai/api.ts
@@ -1,6 +1,19 @@
 import { STORAGE_KEYS } from '../../constants/storageKeys';
 
-const BASE_URL = import.meta.env.VITE_CLOUD_FUNCTIONS_URL ?? 'https://asia-southeast1-quantum-ratio-468010-d4.cloudfunctions.net';
+const DEFAULT_API_BASE = 'https://asia-southeast1-quantum-ratio-468010-d4.cloudfunctions.net/api';
+
+const resolveApiBaseUrl = () => {
+  const rawBase =
+    import.meta.env.VITE_API_BASE ?? import.meta.env.VITE_CLOUD_FUNCTIONS_URL ?? DEFAULT_API_BASE;
+
+  const trimmedBase = rawBase.replace(/\/+$/, '');
+  if (/\/api(\/|$)/.test(trimmedBase)) {
+    return trimmedBase;
+  }
+  return `${trimmedBase}/api`;
+};
+
+const BASE_URL = resolveApiBaseUrl();
 
 const resolveApiKey = () => {
   if (typeof window === 'undefined') return '';


### PR DESCRIPTION
## Summary
- normalise the Cloud Functions base URL to ensure the /api segment is always included
- document the Vite environment variable required to reach the deployed API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c842bde083239dc22ecbac228a66