### PR TITLE
Compose AI prompt from all active instructions

### DIFF
--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -2,11 +2,15 @@ export const queryKeys = {
   instructions: ['instructions'] as const,
   instruction: (id: string) => ['instruction', id] as const,
   instructionRules: (instructionId: string) => ['instruction', instructionId, 'rules'] as const,
+  instructionRuleSets: (instructionIds: readonly string[]) =>
+    ['instruction', 'rules', 'set', instructionIds] as const,
   instructionExamples: (instructionId: string, ruleId: string) =>
     ['instruction', instructionId, 'rule', ruleId, 'examples'] as const,
   activeInstruction: ['instructions', 'active'] as const,
+  activeInstructions: ['instructions', 'active', 'all'] as const,
   schemas: ['schemas'] as const,
   activeSchema: ['schemas', 'active'] as const,
+  activeSchemas: ['schemas', 'active', 'all'] as const,
   tours: ['tours'] as const,
   tour: (id: string) => ['tour', id] as const,
   masterData: (type: string) => ['master-data', type] as const,

--- a/src/features/instructions/utils/composePrompt.ts
+++ b/src/features/instructions/utils/composePrompt.ts
@@ -1,20 +1,46 @@
 import { Instruction, InstructionRule } from '../../../types/instruction';
 
-export const composePrompt = (
-  instruction: Instruction | null | undefined,
-  rules: InstructionRule[] | undefined,
-) => {
-  if (!instruction) return '';
-
-  const ruleBlock = (rules ?? [])
+const formatRuleBlock = (rules: InstructionRule[] = []) =>
+  rules
     .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
     .map((rule, index) => {
       const constraints = rule.constraints?.length ? `\n- ${rule.constraints.join('\n- ')}` : '';
       return `Rule ${index + 1}: ${rule.title}${constraints ? `\n${constraints}` : ''}\nOutput: ${rule.output_format}`;
     })
+    .filter(Boolean)
     .join('\n\n');
 
+const formatInstructionBlock = (
+  instruction: Instruction,
+  rules: InstructionRule[] = [],
+  index: number,
+  total: number,
+) => {
   const variableList = instruction.variables?.length ? `\nVariables: {{${instruction.variables.join('}}, {{')}}}` : '';
+  const ruleBlock = formatRuleBlock(rules);
+  const headerPrefix = total > 1 ? `Instruction ${index + 1}` : 'Instruction';
 
-  return `Instruction: ${instruction.title}\nGoal: ${instruction.goal}\n${instruction.body}${variableList}\n\n${ruleBlock}`.trim();
+  return [
+    `${headerPrefix}: ${instruction.title}`,
+    `Goal: ${instruction.goal}`,
+    `${instruction.body}${variableList}`.trim(),
+    ruleBlock,
+  ]
+    .filter((section) => section && section.trim().length > 0)
+    .join('\n');
+};
+
+export const composePrompt = (
+  instructions: Instruction[] | null | undefined,
+  ruleMap: Record<string, InstructionRule[] | undefined> = {},
+) => {
+  const validInstructions = (instructions ?? []).filter(Boolean) as Instruction[];
+  if (!validInstructions.length) return '';
+
+  const blocks = validInstructions.map((instruction, index) => {
+    const rules = ruleMap[instruction.id ?? ''];
+    return formatInstructionBlock(instruction, rules ?? [], index, validInstructions.length);
+  });
+
+  return blocks.filter(Boolean).join('\n\n---\n\n').trim();
 };

--- a/src/routes/InstructionDetailPage.tsx
+++ b/src/routes/InstructionDetailPage.tsx
@@ -35,7 +35,14 @@ const InstructionDetailPage = () => {
 
   const currentInstruction = draftInstruction ?? instruction ?? null;
 
-  const composedPrompt = useMemo(() => composePrompt(instruction, rules), [instruction, rules]);
+  const composedPrompt = useMemo(() => {
+    if (!currentInstruction) return '';
+    const instructionList = [currentInstruction];
+    const ruleMap = currentInstruction.id
+      ? { [currentInstruction.id]: rules ?? [] }
+      : {};
+    return composePrompt(instructionList, ruleMap);
+  }, [currentInstruction, rules]);
 
   const statusLabel: Record<Instruction['status'], string> = {
     draft: 'Nháp',


### PR DESCRIPTION
## Summary
- compose the fallback prompt from every active instruction and its rule set while showing all active schemas on the AI extraction page
- add hooks for fetching all active instructions and schema lists plus update prompt composition utilities to handle multi-instruction inputs
- adjust the instruction detail view to use the new prompt composer and refresh cache invalidations for active instruction/schema queries

## Testing
- npm run lint -- --ignore-pattern functions
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d4cd438b8483239aa493077a4dff18